### PR TITLE
Bugfixes; enhanced FFT compatibility

### DIFF
--- a/GameData/SpaceDustBunnies/Definitions/JNSQ/Eeloo.cfg
+++ b/GameData/SpaceDustBunnies/Definitions/JNSQ/Eeloo.cfg
@@ -1,6 +1,6 @@
 @SPACEDUST_RESOURCE:HAS[#body[Eeloo]]:NEEDS[JNSQ]
 {
-	@RESOURCEBAND[eeloExo]
+	@RESOURCEBAND[eelooExo]
 	{
 		@altUpperBound = 130000
 		@altLowerBound = 90000
@@ -165,7 +165,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 // CELES
 // = = = = =
 
-SPACEDUST_RESOURCE
+SPACEDUST_RESOURCE:NEEDS[JNSQ]
 {
 	resourceName = LqdMethane
 	body = Celes
@@ -200,7 +200,7 @@ SPACEDUST_RESOURCE
 	}
 }
 
-SPACEDUST_RESOURCE
+SPACEDUST_RESOURCE:NEEDS[JNSQ]
 {
 	resourceName = Rock
 	body = Celes
@@ -235,7 +235,7 @@ SPACEDUST_RESOURCE
 	}
 }
 
-SPACEDUST_RESOURCE
+SPACEDUST_RESOURCE:NEEDS[JNSQ]
 {
 	resourceName = Water
 	body = Celes
@@ -247,7 +247,7 @@ SPACEDUST_RESOURCE
 
 		minAbundance = 0.00273
 		maxAbundance = 0.00364
-		
+
 		// Discoverability Data
 		alwaysDiscovered = false
 		alwaysIdentified = false

--- a/GameData/SpaceDustBunnies/Definitions/JNSQ/Lindor.cfg
+++ b/GameData/SpaceDustBunnies/Definitions/JNSQ/Lindor.cfg
@@ -52,7 +52,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		minAbundance = 0.025 // 2
 		maxAbundance = 0.025 // 2
-		
+
 		useAirDensity = True
 		densityCurve
 		{
@@ -94,7 +94,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		minAbundance = 0.0125 // 1
 		maxAbundance = 0.0125 // 1
-		
+
 		useAirDensity = True
 		densityCurve
 		{
@@ -136,7 +136,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		minAbundance = 0.0014375 // 0.115
 		maxAbundance = 0.0014375 // 0.115
-		
+
 		useAirDensity = True
 		densityCurve
 		{
@@ -208,7 +208,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		minAbundance = 0.0875 // 7
 		maxAbundance = 0.1625 // 13
-		
+
 		useAirDensity = True
 		densityCurve
 		{
@@ -250,7 +250,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		minAbundance = 0.8875 // 71
 		maxAbundance = 0.9625 // 77
-		
+
 		useAirDensity = True
 		densityCurve
 		{
@@ -322,7 +322,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		minAbundance = 0.0375 // 3
 		maxAbundance = 0.0625 // 5
-		
+
 		useAirDensity = True
 		densityCurve
 		{
@@ -371,12 +371,12 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		useAirDensity = False
 		distributionType = Spherical
-		
+
 		// These parameters are specific to the Spherical model
 		altUpperBound = 32000000
 		altLowerBound = 14000000
 		altPeak = 23000000
-		
+
 		altVariability = 0
 		altFalloffType = Linear
 
@@ -404,7 +404,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		minAbundance = 0.025 // 2
 		maxAbundance = 0.025 // 2
-		
+
 		useAirDensity = True
 		densityCurve
 		{
@@ -447,12 +447,12 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		useAirDensity = False
 		distributionType = Spherical
-		
+
 		// These parameters are specific to the Spherical model
 		altUpperBound = 18000000
 		altLowerBound = 14000000
 		altPeak = 16000000
-		
+
 		altVariability = 0
 		altFalloffType = Linear
 
@@ -468,7 +468,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 // KREL
 // = = = = =
 
-SPACEDUST_RESOURCE
+SPACEDUST_RESOURCE:NEEDS[JNSQ]
 {
 	resourceName = Rock
 	body = Krel
@@ -506,7 +506,7 @@ SPACEDUST_RESOURCE
 // ADEN
 // = = = = =
 
-SPACEDUST_RESOURCE
+SPACEDUST_RESOURCE:NEEDS[JNSQ]
 {
 	resourceName = Oxidizer
 	body = Aden
@@ -541,7 +541,7 @@ SPACEDUST_RESOURCE
 	}
 }
 
-SPACEDUST_RESOURCE
+SPACEDUST_RESOURCE:NEEDS[JNSQ]
 {
 	resourceName = Rock
 	body = Aden
@@ -576,7 +576,7 @@ SPACEDUST_RESOURCE
 	}
 }
 
-SPACEDUST_RESOURCE
+SPACEDUST_RESOURCE:NEEDS[JNSQ]
 {
 	resourceName = Water
 	body = Aden
@@ -614,7 +614,7 @@ SPACEDUST_RESOURCE
 // TALOS
 // = = = = =
 
-SPACEDUST_RESOURCE
+SPACEDUST_RESOURCE:NEEDS[JNSQ]
 {
 	resourceName = Rock
 	body = Talos
@@ -649,7 +649,7 @@ SPACEDUST_RESOURCE
 	}
 }
 
-SPACEDUST_RESOURCE
+SPACEDUST_RESOURCE:NEEDS[JNSQ]
 {
 	resourceName = Water
 	body = Talos

--- a/GameData/SpaceDustBunnies/Definitions/JNSQ/Nara.cfg
+++ b/GameData/SpaceDustBunnies/Definitions/JNSQ/Nara.cfg
@@ -2,7 +2,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 {
 	resourceName = Antimatter
 	body = Nara
-	
+
 	RESOURCEBAND
 	{
 		name = naraExo
@@ -86,7 +86,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		minAbundance = 0.0014375 // 0.115
 		maxAbundance = 0.0014375 // 0.115
-		
+
 		useAirDensity = True
 		densityCurve
 		{
@@ -158,7 +158,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		minAbundance = 0.0875 // 7
 		maxAbundance = 0.1625 // 13
-		
+
 		useAirDensity = True
 		densityCurve
 		{
@@ -200,7 +200,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		minAbundance = 1 // 80
 		maxAbundance = 1.125 // 90
-		
+
 		useAirDensity = True
 		densityCurve
 		{
@@ -280,12 +280,12 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		useAirDensity = False
 		distributionType = Spherical
-		
+
 		// These parameters are specific to the Spherical model
 		altUpperBound = 32000000
 		altLowerBound = 12000000
 		altPeak = 22000000
-		
+
 		altVariability = 0
 		altFalloffType = Linear
 
@@ -321,12 +321,12 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		useAirDensity = False
 		distributionType = Spherical
-		
+
 		// These parameters are specific to the Spherical model
 		altUpperBound = 22000000
 		altLowerBound = 12000000
 		altPeak = 17000000
-		
+
 		altVariability = 0
 		altFalloffType = Linear
 
@@ -342,7 +342,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 // ENON
 // = = = = =
 
-SPACEDUST_RESOURCE
+SPACEDUST_RESOURCE:NEEDS[JNSQ]
 {
 	resourceName = Oxidizer
 	body = Enon
@@ -377,7 +377,7 @@ SPACEDUST_RESOURCE
 	}
 }
 
-SPACEDUST_RESOURCE
+SPACEDUST_RESOURCE:NEEDS[JNSQ]
 {
 	resourceName = Rock
 	body = Enon
@@ -412,7 +412,7 @@ SPACEDUST_RESOURCE
 	}
 }
 
-SPACEDUST_RESOURCE
+SPACEDUST_RESOURCE:NEEDS[JNSQ]
 {
 	resourceName = Water
 	body = Enon
@@ -450,7 +450,7 @@ SPACEDUST_RESOURCE
 // PRAX
 // = = = = =
 
-SPACEDUST_RESOURCE
+SPACEDUST_RESOURCE:NEEDS[JNSQ]
 {
 	resourceName = Water
 	body = Prax

--- a/GameData/SpaceDustBunnies/Definitions/JNSQ/Riga.cfg
+++ b/GameData/SpaceDustBunnies/Definitions/JNSQ/Riga.cfg
@@ -13,7 +13,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		minAbundance = 0.0000375 // 0.003
 		maxAbundance = 0.0000375 // 0.003
-		
+
 		useAirDensity = True
 		densityCurve
 		{
@@ -55,7 +55,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		minAbundance = 0.025 // 2
 		maxAbundance = 0.025 // 2
-		
+
 		useAirDensity = True
 		densityCurve
 		{
@@ -90,13 +90,13 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		minAbundance = 0.01105
 		maxAbundance = 0.03005
-		
+
 		// Visuals Data
 		countScale = 0.5
 		rotateRate = 1
-		
+
 		useAirDensity = False
-		
+
 		// Distribution Data
 		distributionType = Spherical
 
@@ -131,7 +131,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		minAbundance = 1.125 // 90
 		maxAbundance = 1.125 // 90
-		
+
 		useAirDensity = True
 		densityCurve
 		{
@@ -158,7 +158,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 	}
 }
 
-SPACEDUST_RESOURCE
+SPACEDUST_RESOURCE:NEEDS[JNSQ]
 {
 	resourceName = LqdMethane
 	body = Riga
@@ -195,7 +195,7 @@ SPACEDUST_RESOURCE
 	}
 }
 
-SPACEDUST_RESOURCE
+SPACEDUST_RESOURCE:NEEDS[JNSQ]
 {
 	resourceName = Water
 	body = Riga

--- a/GameData/SpaceDustBunnies/Definitions/JNSQ/Tylo.cfg
+++ b/GameData/SpaceDustBunnies/Definitions/JNSQ/Tylo.cfg
@@ -50,7 +50,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		minAbundance = 0.0000375 // 0.003
 		maxAbundance = 0.0000375 // 0.003
-		
+
 		useAirDensity = True
 		densityCurve
 		{
@@ -90,7 +90,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		minAbundance = 0.025 // 2
 		maxAbundance = 0.025 // 2
-		
+
 		useAirDensity = True
 		densityCurve
 		{
@@ -130,7 +130,7 @@ SPACEDUST_RESOURCE:NEEDS[JNSQ]
 
 		minAbundance = 1.1 // 88
 		maxAbundance = 1.15 // 92
-		
+
 		useAirDensity = True
 		densityCurve
 		{

--- a/GameData/SpaceDustBunnies/Patches/SpaceDustHarvestersCRP.cfg
+++ b/GameData/SpaceDustBunnies/Patches/SpaceDustHarvestersCRP.cfg
@@ -1,7 +1,7 @@
 // Adds Nertea-suite CRP harvesting
 // ------------------------------
 
-@PART[spacedust-atmosphere-processor-125-1|spacedust-atmosphere-processor-25-1]:AFTER[SpaceDust]:NEEDS[CommunityResourcePack]
+@PART[spacedust-atmosphere-processor-125-1|spacedust-atmosphere-processor-25-1|fft-atmosphere-scoop-1]:AFTER[SpaceDust]:NEEDS[CommunityResourcePack]
 {
 	@MODULE[ModuleSpaceDustHarvester]
 	{
@@ -15,17 +15,83 @@
 			Name = LqdCO2
 			BaseEfficiency = 1
 		}
-		%HARVESTED_RESOURCE[LqdDeuterium]
+		HARVESTED_RESOURCE
 		{
-			%BaseEfficiency = 1
+			Name = LqdMethane
+			BaseEfficiency = 1
 		}
-		%HARVESTED_RESOURCE[LqdHe3]
+		HARVESTED_RESOURCE
 		{
-			%BaseEfficiency = 1
+			Name = LqdNitrogen
+			BaseEfficiency = 1
 		}
-		%HARVESTED_RESOURCE[LqdHydrogen]
+		HARVESTED_RESOURCE
 		{
-			%BaseEfficiency = 1
+			Name = Rock
+			BaseEfficiency = 1
+		}
+		HARVESTED_RESOURCE
+		{
+			Name = Water
+			BaseEfficiency = 1
+		}
+	}
+}
+
+@PART[spacedust-atmosphere-processor-125-1|spacedust-atmosphere-processor-25-1]:AFTER[SpaceDust]:NEEDS[CommunityResourcePack,!NearFuturePropulsion]
+{
+	@MODULE[ModuleSpaceDustHarvester]
+	{
+		HARVESTED_RESOURCE
+    {
+      Name = ArgonGas
+      BaseEfficiency = 1
+    }
+	}
+}
+
+@PART[spacedust-atmosphere-processor-125-1|spacedust-atmosphere-processor-25-1]:AFTER[SpaceDust]:NEEDS[CommunityResourcePack,!CryoTanks]
+{
+	@MODULE[ModuleSpaceDustHarvester]
+	{
+		HARVESTED_RESOURCE
+    {
+      Name = LqdHydrogen
+      BaseEfficiency = 1
+    }
+	}
+}
+
+@PART[spacedust-atmosphere-processor-125-1|spacedust-atmosphere-processor-25-1]:AFTER[SpaceDust]:NEEDS[CommunityResourcePack,!FarFutureTechnologies]
+{
+	@MODULE[ModuleSpaceDustHarvester]
+	{
+		HARVESTED_RESOURCE
+		{
+			Name = LqdHe3
+			BaseEfficiency = 1
+		}
+		HARVESTED_RESOURCE
+		{
+			Name = LqdDeuterium
+			BaseEfficiency = 1
+		}
+	}
+}
+
+@PART[fft-exosphere-scoop-1]:AFTER[SpaceDust]:NEEDS[CommunityResourcePack,FarFutureTechnologies]
+{
+	@MODULE[ModuleSpaceDustHarvester]
+	{
+		HARVESTED_RESOURCE
+		{
+			Name = LqdAmmonia // not defined as an exospheric resource, but included anyway for completeness
+			BaseEfficiency = 1
+		}
+		HARVESTED_RESOURCE
+		{
+			Name = LqdCO2
+			BaseEfficiency = 1
 		}
 		HARVESTED_RESOURCE
 		{

--- a/GameData/SpaceDustBunnies/Patches/SpaceDustScannersCRP.cfg
+++ b/GameData/SpaceDustBunnies/Patches/SpaceDustScannersCRP.cfg
@@ -520,6 +520,33 @@
 				}
 			}
 		}
+		SUBTYPE:NEEDS[!FarFutureTechnologies]
+		{
+			name = D2Instrument
+			title = #LOC_SpaceDust_switcher_instrument_de
+			descriptionSummary = #LOC_SpaceDust_switcher_instrument_de_summary
+			descriptionDetail = #LOC_SpaceDust_switcher_instrument_de_detail
+			primaryColor = PowderBlue
+			secondaryColor = PowderBlue
+			addedMass = 0.2
+			addedCost = 50000
+
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleSpaceDustTelescope
+				}
+				DATA
+				{
+					SLOT
+					{
+						name = slot2
+						Instrument = DeuteriumSpectrometer
+					}
+				}
+			}
+		}
 		SUBTYPE:NEEDS[!CryoTanks]
 		{
 			name = LH2Instrument

--- a/GameData/SpaceDustBunnies/Patches/SpaceDustScannersCRP.cfg
+++ b/GameData/SpaceDustBunnies/Patches/SpaceDustScannersCRP.cfg
@@ -22,14 +22,14 @@
 			DiscoverRange = 0
 			IdentifyRange = 0
 		}
-		%SCANNED_RESOURCE[LqdDeuterium]
+		%SCANNED_RESOURCE[LqdDeuterium]:NEEDS[!FarFutureTechnologies]
 		{
 			%DiscoverMode = Local
 			%IdentifyMode = Local
 			%DiscoverRange = 0
 			%IdentifyRange = 0
 		}
-		%SCANNED_RESOURCE[LqdHe3]
+		%SCANNED_RESOURCE[LqdHe3]:NEEDS[!FarFutureTechnologies]
 		{
 			%DiscoverMode = Local
 			%IdentifyMode = Local
@@ -110,14 +110,14 @@
 			DiscoverRange = 300000
 			IdentifyRange = 100000
 		}
-		%SCANNED_RESOURCE[LqdDeuterium]
+		%SCANNED_RESOURCE[LqdDeuterium]:NEEDS[!FarFutureTechnologies]
 		{
 			%DiscoverMode = Altitude
 			%IdentifyMode = Altitude
 			%DiscoverRange = 300000
 			%IdentifyRange = 100000
 		}
-		%SCANNED_RESOURCE[LqdHe3]
+		%SCANNED_RESOURCE[LqdHe3]:NEEDS[!FarFutureTechnologies]
 		{
 			%DiscoverMode = Altitude
 			%IdentifyMode = Altitude
@@ -268,7 +268,6 @@
 				}
 			}
 		}
-		CloudyBlue
 		SUBTYPE:NEEDS[!FarFutureTechnologies]
 		{
 			name = D2Instrument


### PR DESCRIPTION
Bugfixes: 
- If FFT was not installed, Deuterium spectrometer was available for slot 1 of telescope but not slot 2.
- Fixed broken addition/modification of LqdHydrogen, LqdDeuterium, LqdHe3 in SpaceDust harvesters. ModuleSpaceDustHarvester uses titlecase "Name" key while MM % operation uses lowercase "name" key. These have been broken out into individual patches. This also fixes the resources following these alphabetically (LqdMethane, LqdNitrogen, Rock, Water) in that patch.
- Add :NEEDS[JNSQ] tags where missing in the JNSQ patches. The absence of these would break SpaceDust in non-JNSQ games.

Enhancements:
- DustBunnies was adding D2/He3 scanning capabilities to the SpaceDust scanner/analyzer, which rendered the gas scanner in FFT redundant. Now the SpaceDust scanner/analyzer only include D2/He3 if FFT is not installed.
- FFT exo scoop now includes the six resources added by DustBunnies. It was previously impossible to actually harvest the additional exospheric resources from DustBunnies.
- FFT atmo scoop now harvests the additional DustBunnies resources, just like the SpaceDust atmo harvesters.
- Added Argon to the SpaceDust atmo harvesters if NFP not installed.